### PR TITLE
fix: CI workflow job names and commands for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,122 +8,119 @@ on:
 
 jobs:
   lint:
-    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Git
         run: |
           sudo apt-get update
           sudo apt-get install -y git
-      
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           version: latest
           virtualenvs-create: true
           virtualenvs-in-project: true
-          
+
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-          
+
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --with dev,test
-        
+
       - name: Run linting
         run: |
-          poetry run make lint
-          
+          make lint
+
   test:
-    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Git
         run: |
           sudo apt-get update
           sudo apt-get install -y git
-      
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           version: latest
           virtualenvs-create: true
           virtualenvs-in-project: true
-          
+
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-          
+
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --with dev,test
-        
+
       - name: Run tests
         env:
           PYTHONPATH: src
         run: |
-          poetry run pytest tests/unit/ -v --tb=short
-          
+          make test
+
   security:
-    name: Security
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Git
         run: |
           sudo apt-get update
           sudo apt-get install -y git
-      
+
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          
+
       - name: Install Poetry
         uses: snok/install-poetry@v1
         with:
           version: latest
           virtualenvs-create: true
           virtualenvs-in-project: true
-          
+
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
-          
+
       - name: Install dependencies
         if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --with dev,test
-        
+
       - name: Run security checks
         run: |
           poetry run bandit -r src/ -f json -o bandit-report.json || true
           poetry run safety check --json --output safety-report.json || true
-          
+
       - name: Upload security reports
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -38,33 +38,33 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          
+
       - name: setup reports-dir
         run: mkdir "$REPORTS_DIR"
-        
+
       - name: Setup python ${{ env.PYTHON_VERSION }}
         # see https://github.com/actions/setup-python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           architecture: 'x64'
-          
+
       - name: Setup poetry ${{ env.POETRY_VERSION }}
         # see https://github.com/marketplace/actions/setup-poetry
         uses: Gr1N/setup-poetry@v9
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
-          
+
       - name: bump version
         id: bump-version
         run: |
           VERSION="${{ github.run_id }}.${{ github.run_number }}.${{ github.run_attempt }}+testing"
           poetry version "$VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          
+
       - name: Poetry build
         run: poetry build
-        
+
       - name: Build Docker image
         env:
           VERSION: ${{ steps.bump-version.outputs.version }}
@@ -75,12 +75,12 @@ jobs:
           --build-arg "VERSION=$VERSION"
           -t "$DOCKER_TAG"
           ../mcp_auto_pr/docker/analyzer/
-          
+
       - name: Test Docker image
         run: >
           docker run --rm "$DOCKER_TAG"
           python -c "import mcp_local_repo_analyzer; print('Docker image test passed')"
-          
+
       - name: Build own SBoM (XML)
         run: >
           docker run --rm "$DOCKER_TAG"
@@ -88,7 +88,7 @@ jobs:
           -vvv
           --output-format XML
           > "$REPORTS_DIR/docker-image.bom.xml"
-          
+
       - name: Build own SBoM (JSON)
         run: >
           docker run --rm "$DOCKER_TAG"
@@ -96,7 +96,7 @@ jobs:
           -vvv
           --output-format JSON
           > "$REPORTS_DIR/docker-image.bom.json"
-          
+
       - name: Artifact reports
         if: ${{ ! cancelled() }}
         # see https://github.com/actions/upload-artifact
@@ -105,8 +105,8 @@ jobs:
           name: ${{ env.REPORTS_ARTIFACT }}
           path: ${{ env.REPORTS_DIR }}
           if-no-files-found: error
-          
+
       - name: Destroy Docker image
         # run regardless of outcome
         if: ${{ always() }}
-        run: docker rmi -f "$DOCKER_TAG" 
+        run: docker rmi -f "$DOCKER_TAG"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,14 +12,11 @@
 name: Lint
 
 on:
-  push:
-    branches: [ master, main ]
   pull_request:
     branches: [ master, main ]
 
 jobs:
   lint:
-    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,7 +27,7 @@ jobs:
           sudo apt-get install -y git
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
@@ -43,7 +40,7 @@ jobs:
 
       - name: Load cached venv
         id: cached-poetry-dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: .venv
           key: venv-${{ runner.os }}-${{ steps.setup-python.outputs.python-version }}-${{ hashFiles('**/poetry.lock') }}
@@ -54,4 +51,4 @@ jobs:
 
       - name: Run linting
         run: |
-          poetry run make lint
+          make lint


### PR DESCRIPTION
## Summary
- Remove job name fields to match branch protection checks exactly (lint, test, security)
- Change 'poetry run make lint' to 'make lint' for consistency
- Change 'poetry run pytest' to 'make test' to use Makefile targets
- Remove duplicate push trigger from lint.yml workflow to prevent duplicate runs
- Update GitHub Actions versions (@v4 to @v5, @v3 to @v4)

## Problem
GitHub branch protection is expecting checks named exactly 'lint', 'test', 'security' but the current workflows have job names that don't match, causing CI failures.

## Solution
Remove the explicit job names so GitHub uses the job IDs as check names, ensuring perfect alignment with branch protection requirements.